### PR TITLE
Fix. Add shipping refund line to DailySales report if shipping_credit_amount property exists

### DIFF
--- a/SyncApp/Logic/ExportDailySalesLogic.cs
+++ b/SyncApp/Logic/ExportDailySalesLogic.cs
@@ -412,6 +412,7 @@ namespace SyncAppEntities.Logic
 
             var storeCreditLineItems = new Dictionary<long, decimal>();
             var isShippingRefund = false;
+            decimal shippingCreditAmount = 0;
             decimal? extraStoreCreditVal = null;
             if (storeCreditRefunds?.Value != null)
             {
@@ -447,8 +448,8 @@ namespace SyncAppEntities.Logic
 
                             if (storeCreditRefund.ShippingCreditAmount > 0)
                             {
-
                                 isShippingRefund = true;
+                                shippingCreditAmount = storeCreditRefund.ShippingCreditAmount;
                             }
 
                             if (!string.IsNullOrWhiteSpace(storeCreditRefund.CreditCompensationAmount) &&
@@ -770,7 +771,9 @@ namespace SyncAppEntities.Logic
                 }
             }
 
-            if (shippingAmount > 0 && isShippingRefund)
+            var shipping = isShippingRefund ? shippingCreditAmount : shippingAmount;
+
+            if (shipping > 0 && isShippingRefund)
             {
                 var mQuant = "-1";
 
@@ -786,7 +789,7 @@ namespace SyncAppEntities.Logic
                     "1" + "\t" +
                     partNumber.InsertLeadingSpaces(15) + "\t" +
                     mQuant.ToString().InsertLeadingSpaces(10).InsertLeadingSpaces(10) + "\t" + // total quantity 
-                    shippingAmount.GetNumberWithDecimalPlaces(4).InsertLeadingSpaces(10) + "\t" + // unit price without tax
+                    shipping.GetNumberWithDecimalPlaces(4).InsertLeadingSpaces(10) + "\t" + // unit price without tax
                     "".InsertLeadingSpaces(4) + "\t" + // agent code
                     discountZero.ToString("F") +
                     "\t" + "\t" + "\t" +

--- a/SyncApp/Logic/ExportDailySalesLogic.cs
+++ b/SyncApp/Logic/ExportDailySalesLogic.cs
@@ -449,7 +449,7 @@ namespace SyncAppEntities.Logic
                             if (storeCreditRefund.ShippingCreditAmount > 0)
                             {
                                 isShippingRefund = true;
-                                shippingCreditAmount = storeCreditRefund.ShippingCreditAmount;
+                                shippingCreditAmount = storeCreditRefund.ShippingCreditAmount.ValueWithoutTax(taxPercentage);
                             }
 
                             if (!string.IsNullOrWhiteSpace(storeCreditRefund.CreditCompensationAmount) &&


### PR DESCRIPTION
Bug description:

We see that shipping refunds to credit are not calculated in the reports:

ORDER: 497440    26/01/26

<img width="992" height="37" alt="image" src="https://github.com/user-attachments/assets/d06f1d7f-846a-44d7-b3b5-81ddfa9526de" />


ORDER: 486165    04/01/26

<img width="1014" height="81" alt="image" src="https://github.com/user-attachments/assets/95592d7f-318f-470b-8911-13caa6f0506a" />


These orders have 1 refund to credit, including shipping:

A reminder of how the process should be - if a credit refund has a "shipping_credit_amount" property, add a shipping line refund with the property value.

<img width="467" height="448" alt="image" src="https://github.com/user-attachments/assets/3407007f-06d1-47c9-8a95-98e8c18c130f" />


